### PR TITLE
Updated guzzlehttp version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Guzzle 6 Middleware
-This is a Guzzle 6 middleware, which allows you to profile an http call, and send information to statsd daemon.
+# Guzzle Middleware
+This is a Guzzle middleware, which allows you to profile an http call, and send information to statsd daemon.
 ## Requirements
 
 ### Dependencies
@@ -7,7 +7,7 @@ This is a Guzzle 6 middleware, which allows you to profile an http call, and sen
 | Dependency | Version 
 |:--- |:---:|
 | **`php`** | ^7.2 |
-| **`guzzlehttp/guzzle`** | ^6.0 | 
+| **`guzzlehttp/guzzle`** | ^6.0&#124;^7.0 | 
 | **`liuggio/statsd-php-client`** | ^1.0 | 
 | **`domnikl/statsd`** | ^2.0 |
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^6.0|^7.0",
         "liuggio/statsd-php-client": "^1.0",
         "domnikl/statsd": "^2.0|^3.0"
     },


### PR DESCRIPTION
There are no breaking changes in the interfaces that this project uses between [versions 6 and 7](https://github.com/guzzle/guzzle/blob/master/UPGRADING.md#60-to-70). This won't affect the functionality, but allow upgrading guzzlehttp/guzzle to version 7 on projects that use this package.